### PR TITLE
Don't bind home directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Dockerfile.personal
+.db-dev
+.db-deps

--- a/Dockerfile.personal.tmpl
+++ b/Dockerfile.personal.tmpl
@@ -1,7 +1,7 @@
 FROM db-deps
 
 # docker build -t db-dev . -f Dockerfile.personal
-# docker run --rm -it -v ~:/home/$USER -u $USER -h dev.local db-dev
+# docker run --rm -it -v `pwd`:/home/$USER -u $USER -h dev.local db-dev
 
 ENV USER=__USER__ \
     GROUP=__GROUP__ \

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,24 @@
+all: run
+
+
 Dockerfile.personal:
-	./substitute
+	@./substitute
+
+.db-deps:
+	@docker build -t db-deps . && touch .db-deps
+
+.db-dev: .db-deps Dockerfile.personal
+	@docker build -t db-dev . -f Dockerfile.personal && touch .db-dev
+
+run: .db-dev
+	@docker run --rm -it -v `pwd`:/app -u $$USER -h dev.local db-dev
+
+stop:
+	@docker stop $(docker ps -a -q --filter ancestor=db-dev --format="{{.ID}}") 2>/dev/null || true
+
+clean: stop
+	@docker rmi -f db-dev
+	@docker rmi -f db-deps
+	@rm -f .db-deps
+	@rm -f .db-dev
+	@rm -f Dockerfile.personal


### PR DESCRIPTION
Binding home directory causes number of issues:
 - it is very slow on MacOS using hyperkit
 - it gives access to hidden files in ~/ which could contain sensitive information or cridentials

This PR binds current working directory to docker. If you want old behavior just start the environment from HOME directory.

It also adds few helper targets to make file (RFC). 